### PR TITLE
feat(auth): require password change before login after admin reset

### DIFF
--- a/src/main/java/com/winten/greenlight/admin/api/controller/user/UserController.java
+++ b/src/main/java/com/winten/greenlight/admin/api/controller/user/UserController.java
@@ -88,6 +88,30 @@ public class UserController {
                 .body(userConverter.toResponse(loginResult));
     }
 
+    /**
+     * 관리자 비밀번호 초기화 후, 로그인 전에 새 비밀번호로 변경한다.
+     * 인증 토큰을 발급하지 않으며, 기존 refresh 쿠키가 있으면 삭제한다.
+     */
+    @PostMapping("password/change-required")
+    public ResponseEntity<Void> changePasswordWhenResetRequired(
+            @RequestBody @Valid final UserPasswordChangeRequiredRequest request
+    ) {
+        userService.changePasswordWhenResetRequired(
+                request.getLoginId(),
+                request.getCurrentPassword(),
+                request.getNewPassword()
+        );
+        var deleteRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .sameSite("lax")
+                .path("/")
+                .maxAge(0)
+                .build();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, deleteRefreshTokenCookie.toString())
+                .build();
+    }
+
     @PostMapping("refresh")
     public ResponseEntity<UserLoginResponse> refresh(
             @CookieValue(value = "refreshToken", required = false) String refreshToken,

--- a/src/main/java/com/winten/greenlight/admin/api/controller/user/UserPasswordChangeRequiredRequest.java
+++ b/src/main/java/com/winten/greenlight/admin/api/controller/user/UserPasswordChangeRequiredRequest.java
@@ -1,0 +1,22 @@
+package com.winten.greenlight.admin.api.controller.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPasswordChangeRequiredRequest {
+    @NotBlank
+    private String loginId;
+
+    @NotBlank
+    private String currentPassword;
+
+    @NotBlank
+    @Size(min = 8, max = 100)
+    private String newPassword;
+}

--- a/src/main/java/com/winten/greenlight/admin/domain/user/UserService.java
+++ b/src/main/java/com/winten/greenlight/admin/domain/user/UserService.java
@@ -111,6 +111,14 @@ public class UserService {
 
         ensureSiteEnabled(user);
 
+        // 관리자 비밀번호 초기화 직후: 토큰을 발급하지 않고 비밀번호 변경을 강제한다.
+        if (Boolean.TRUE.equals(user.getPasswordResetRequired())) {
+            throw CoreException.of(
+                    ErrorType.USER_PASSWORD_RESET_REQUIRED,
+                    "비밀번호 변경 후 로그인할 수 있습니다."
+            );
+        }
+
         // 여기까지 도달했다면 정상 로그인 된 케이스
         loginAttemptTxService.updatePasswordErrorCountById(user.getUserId(), 0); // 로그인 성공 시 password 오류횟수 초기화
 
@@ -631,6 +639,58 @@ public class UserService {
         return findUserById(currentUser.getUserId());
     }
 
+    /**
+     * 로그인 전(비인증) 강제 비밀번호 변경.
+     * password_reset_required 계정만 허용하며, 토큰은 발급하지 않는다.
+     */
+    @Transactional
+    public void changePasswordWhenResetRequired(String loginId, String currentPassword, String newPassword) {
+        var userLoginAttempt = userMapper.findUserLoginAttempt(
+                UserLoginAttempt.builder().loginId(loginId).build()
+        );
+        User user = userMapper.findUserWithCredential(loginId).orElse(new User());
+
+        if (userLoginAttempt == null) {
+            userLoginAttempt = UserLoginAttempt.builder()
+                    .loginId(loginId)
+                    .userId(user.getUserId())
+                    .passwordErrorCount(0)
+                    .build();
+            loginAttemptTxService.saveNewLoginAttempt(userLoginAttempt);
+        }
+
+        if (userLoginAttempt.getPasswordErrorCount() >= 5) {
+            throw CoreException.of(
+                    ErrorType.USER_ACCOUNT_LOCKED,
+                    "비밀번호 입력 오류가 5회 누적되어 계정 이용이 제한되었습니다. '비밀번호 재설정'을 진행해 주세요."
+            );
+        }
+
+        if (!passwordManager.matches(currentPassword, user.getPasswordHash())) {
+            loginAttemptTxService.updatePasswordErrorCountById(loginId, userLoginAttempt.getPasswordErrorCount() + 1);
+            throw CoreException.of(ErrorType.UNAUTHORIZED, "ID 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        if (user.getAccountStatus() != AccountStatus.ACTIVE) {
+            throw CoreException.of(ErrorType.USER_ACCOUNT_LOCKED, "사용할 수 없는 계정입니다.");
+        }
+
+        ensureSiteEnabled(user);
+
+        if (!Boolean.TRUE.equals(user.getPasswordResetRequired())) {
+            throw CoreException.of(ErrorType.INVALID_DATA, "비밀번호 초기화가 필요하지 않은 계정입니다.");
+        }
+
+        if (passwordManager.matches(newPassword, user.getPasswordHash())) {
+            throw CoreException.of(ErrorType.INVALID_DATA, "현재 비밀번호와 다른 비밀번호를 입력해 주세요.");
+        }
+
+        user.setPasswordHash(passwordManager.encode(newPassword));
+        user.setUpdatedBy(user.getUserId());
+        userMapper.updateUserPassword(user);
+        loginAttemptTxService.updatePasswordErrorCountById(loginId, 0);
+    }
+
     public UserToken refresh(String refreshToken, Boolean autoLogin) {
         if (!jwtUtil.validateToken(refreshToken)) {
             throw new CoreException(ErrorType.UNAUTHORIZED, "Refresh Token is Invalid or expired");
@@ -640,6 +700,14 @@ public class UserService {
                 .orElseThrow(() -> CoreException.of(ErrorType.UNAUTHORIZED, "Invalid Token ID"));
         if (user.getAccountStatus() != AccountStatus.ACTIVE) {
             throw new CoreException(ErrorType.UNAUTHORIZED, "사용할 수 없는 계정입니다.");
+        }
+
+        // 초기화 필요 계정은 세션 복원을 허용하지 않는다.
+        if (Boolean.TRUE.equals(user.getPasswordResetRequired())) {
+            throw CoreException.of(
+                    ErrorType.USER_PASSWORD_RESET_REQUIRED,
+                    "비밀번호 변경 후 로그인할 수 있습니다."
+            );
         }
 
         ensureSiteEnabled(user);

--- a/src/main/java/com/winten/greenlight/admin/support/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/winten/greenlight/admin/support/security/JwtAuthenticationFilter.java
@@ -45,11 +45,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 if (user.getAccountStatus() != AccountStatus.ACTIVE) {
                     throw CoreException.of(ErrorType.UNAUTHORIZED, "사용할 수 없는 계정입니다.");
                 }
-                if (Boolean.TRUE.equals(user.getPasswordResetRequired())
-                        && !isPasswordResetFlowRequest(request)) {
+                // 초기화 필요 계정은 인증 세션을 허용하지 않는다. (로그인 전 public 변경 API 사용)
+                if (Boolean.TRUE.equals(user.getPasswordResetRequired())) {
                     throw CoreException.of(
                             ErrorType.USER_PASSWORD_RESET_REQUIRED,
-                            "비밀번호 변경 후 다른 기능을 이용할 수 있습니다."
+                            "비밀번호 변경 후 로그인할 수 있습니다."
                     );
                 }
 
@@ -84,14 +84,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
         filterChain.doFilter(request, response);
-    }
-
-    private boolean isPasswordResetFlowRequest(HttpServletRequest request) {
-        String path = request.getServletPath();
-        String method = request.getMethod();
-        return ("GET".equals(method) && "/users/me".equals(path))
-                || ("PUT".equals(method) && "/users/me/password".equals(path))
-                || ("POST".equals(method) && "/users/logout".equals(path));
     }
 
     private Collection<? extends GrantedAuthority> getAuthorities(UserRole role) {

--- a/src/main/java/com/winten/greenlight/admin/support/security/SecurityConfig.java
+++ b/src/main/java/com/winten/greenlight/admin/support/security/SecurityConfig.java
@@ -42,7 +42,14 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS)
                 .requestMatchers(CorsUtils::isPreFlightRequest)
                 .requestMatchers(HttpMethod.GET, "/health", "/favicon.ico", "/sites/*")
-                .requestMatchers(HttpMethod.POST, "/users/login", "/users/signin", "/users/refresh", "/alerts/**")
+                .requestMatchers(
+                        HttpMethod.POST,
+                        "/users/login",
+                        "/users/signin",
+                        "/users/refresh",
+                        "/users/password/change-required",
+                        "/alerts/**"
+                )
                 .requestMatchers("/error")
                 .requestMatchers("/swagger-ui/**")
                 .requestMatchers("/api-docs/**")
@@ -74,7 +81,14 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.OPTIONS).permitAll()
                     .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                     .requestMatchers(HttpMethod.GET, "/health", "/favicon.ico", "/sites/*").permitAll()
-                    .requestMatchers(HttpMethod.POST, "/users/login", "/users/signin", "/users/refresh", "/alerts/**").permitAll()
+                    .requestMatchers(
+                            HttpMethod.POST,
+                            "/users/login",
+                            "/users/signin",
+                            "/users/refresh",
+                            "/users/password/change-required",
+                            "/alerts/**"
+                    ).permitAll()
                     .requestMatchers("/error").permitAll()
                     .requestMatchers("/action-events/traffic/sse/stream").permitAll()
                     .requestMatchers("/swagger-ui/**").permitAll()

--- a/src/test/java/com/winten/greenlight/admin/domain/user/UserServiceTest.java
+++ b/src/test/java/com/winten/greenlight/admin/domain/user/UserServiceTest.java
@@ -27,7 +27,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -184,6 +186,100 @@ class UserServiceTest {
                 LoginInfo.builder().loginId("super").password("password123!").build()
         ).getAccessToken()).isEqualTo("token");
         verify(siteMapper, never()).findSiteById(any());
+    }
+
+    @Test
+    void loginRejectsWhenPasswordResetRequiredWithoutIssuingToken() {
+        PasswordManager passwordManager = new PasswordManager();
+        UserService service = createService(passwordManager);
+        User user = activeUser("user", "site-a", UserRole.USER);
+        user.setPasswordHash(passwordManager.encode("TempPass123!"));
+        user.setPasswordResetRequired(true);
+
+        when(userMapper.findUserLoginAttempt(any())).thenReturn(
+                UserLoginAttempt.builder().loginId("user").userId("user").passwordErrorCount(0).build()
+        );
+        when(userMapper.findUserWithCredential("user")).thenReturn(Optional.of(user));
+        when(siteMapper.findSiteById(any())).thenReturn(
+                Optional.of(SiteInfo.builder().siteId("site-a").siteEnabled(true).build())
+        );
+
+        assertThatThrownBy(() -> service.login(
+                LoginInfo.builder().loginId("user").password("TempPass123!").build()
+        ))
+                .isInstanceOf(CoreException.class)
+                .satisfies(error -> {
+                    CoreException coreException = (CoreException) error;
+                    assertThat(coreException.getErrorType()).isEqualTo(ErrorType.USER_PASSWORD_RESET_REQUIRED);
+                });
+        verify(jwtUtil, never()).generateToken(any(), any(), any());
+        verify(loginAttemptTxService, never()).updatePasswordErrorCountById(anyString(), anyInt());
+    }
+
+    @Test
+    void refreshRejectsWhenPasswordResetRequired() {
+        UserService service = createService(new PasswordManager());
+        User user = activeUser("user", "site-a", UserRole.USER);
+        user.setPasswordResetRequired(true);
+        when(jwtUtil.validateToken("refresh-token")).thenReturn(true);
+        when(jwtUtil.getCurrentUserFromToken("refresh-token")).thenReturn(
+                CurrentUser.builder().userId("user").userRole(UserRole.USER).userSiteId("site-a").build()
+        );
+        when(userMapper.findUserById("user")).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> service.refresh("refresh-token", false))
+                .isInstanceOf(CoreException.class)
+                .extracting(error -> ((CoreException) error).getErrorType())
+                .isEqualTo(ErrorType.USER_PASSWORD_RESET_REQUIRED);
+        verify(jwtUtil, never()).generateToken(any(), any(), any());
+    }
+
+    @Test
+    void changePasswordWhenResetRequiredUpdatesPasswordWithoutToken() {
+        PasswordManager passwordManager = new PasswordManager();
+        UserService service = createService(passwordManager);
+        User user = activeUser("user", "site-a", UserRole.USER);
+        user.setPasswordHash(passwordManager.encode("TempPass123!"));
+        user.setPasswordResetRequired(true);
+
+        when(userMapper.findUserLoginAttempt(any())).thenReturn(
+                UserLoginAttempt.builder().loginId("user").userId("user").passwordErrorCount(0).build()
+        );
+        when(userMapper.findUserWithCredential("user")).thenReturn(Optional.of(user));
+        when(siteMapper.findSiteById(any())).thenReturn(
+                Optional.of(SiteInfo.builder().siteId("site-a").siteEnabled(true).build())
+        );
+
+        service.changePasswordWhenResetRequired("user", "TempPass123!", "NewPass123!");
+
+        ArgumentCaptor<User> updated = ArgumentCaptor.forClass(User.class);
+        verify(userMapper).updateUserPassword(updated.capture());
+        assertThat(passwordManager.matches("NewPass123!", updated.getValue().getPasswordHash())).isTrue();
+        verify(loginAttemptTxService).updatePasswordErrorCountById("user", 0);
+        verify(jwtUtil, never()).generateToken(any(), any(), any());
+    }
+
+    @Test
+    void changePasswordWhenResetRequiredRejectsWhenNotRequired() {
+        PasswordManager passwordManager = new PasswordManager();
+        UserService service = createService(passwordManager);
+        User user = activeUser("user", "site-a", UserRole.USER);
+        user.setPasswordHash(passwordManager.encode("TempPass123!"));
+        user.setPasswordResetRequired(false);
+
+        when(userMapper.findUserLoginAttempt(any())).thenReturn(
+                UserLoginAttempt.builder().loginId("user").userId("user").passwordErrorCount(0).build()
+        );
+        when(userMapper.findUserWithCredential("user")).thenReturn(Optional.of(user));
+        when(siteMapper.findSiteById(any())).thenReturn(
+                Optional.of(SiteInfo.builder().siteId("site-a").siteEnabled(true).build())
+        );
+
+        assertThatThrownBy(() -> service.changePasswordWhenResetRequired("user", "TempPass123!", "NewPass123!"))
+                .isInstanceOf(CoreException.class)
+                .extracting(error -> ((CoreException) error).getErrorType())
+                .isEqualTo(ErrorType.INVALID_DATA);
+        verify(userMapper, never()).updateUserPassword(any());
     }
 
     @Test

--- a/src/test/java/com/winten/greenlight/admin/support/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/winten/greenlight/admin/support/security/JwtAuthenticationFilterTest.java
@@ -46,16 +46,31 @@ class JwtAuthenticationFilterTest {
     }
 
     @Test
-    void resetRequiredUserCanChangeOwnPassword() throws Exception {
+    void resetRequiredUserCannotChangePasswordViaAuthenticatedApi() throws Exception {
         prepareResetRequiredUser();
+        when(jsonMapper.writeValueAsString(any())).thenReturn("{}");
         var request = authenticatedRequest("PUT", "/users/me/password");
         var response = new MockHttpServletResponse();
         var chain = new MockFilterChain();
 
         filter.doFilter(request, response, chain);
 
-        assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(chain.getRequest()).isSameAs(request);
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(chain.getRequest()).isNull();
+    }
+
+    @Test
+    void resetRequiredUserCannotAccessMe() throws Exception {
+        prepareResetRequiredUser();
+        when(jsonMapper.writeValueAsString(any())).thenReturn("{}");
+        var request = authenticatedRequest("GET", "/users/me");
+        var response = new MockHttpServletResponse();
+        var chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(chain.getRequest()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Block token issuance on login/refresh when password_reset_required is set, and add a public change-required endpoint so users can update the temporary password without establishing a session.